### PR TITLE
fix: update script front/back-end handler.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "fb-auto",
-    "version": "1.7.1",
+    "version": "1.7.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "fb-auto",
-            "version": "1.7.1",
+            "version": "1.7.2",
             "license": "MIT",
             "dependencies": {
                 "bcryptjs": "^2.4.3",

--- a/package.json
+++ b/package.json
@@ -38,5 +38,5 @@
         "build:sass": "sass sass:public/css",
         "upgrade": "node upgrade.js"
     },
-    "version": "1.7.1"
+    "version": "1.7.2"
 }

--- a/public/js/base/checkForUpdate.js
+++ b/public/js/base/checkForUpdate.js
@@ -1,12 +1,13 @@
 (async () => {
-    const apiEndpoint = api.misc.update;
-    const resp = await fetch(apiEndpoint);
-    const { success, data, error } = await resp.json();
+    const allCookies = document.cookie;
+    const cookies = allCookies.split(';');
 
-    if (success) {
-        const allCookies = document.cookie;
-        const cookies = allCookies.split(';');
-        if (!cookies.includes('checkUpdate=false')) {
+    if (!cookies.includes('checkUpdates=false')) {
+        const apiEndpoint = api.misc.update;
+        const resp = await fetch(apiEndpoint);
+        const { success, data, error } = await resp.json();
+
+        if (success) {
             if (data.update) {
                 const body = document.querySelector('body');
                 const updateIndicator = document.getElementById('update-indicator');
@@ -14,8 +15,8 @@
                 body.classList.add('update-indicator-visible');
                 updateIndicator.classList.remove('hidden');
             }
+        } else {
+            handleError('Server did not respond with the requested update data.', error);
         }
-    } else {
-        handleError('Server did not respond with the requested update data.', error);
     }
 })();

--- a/utils/update.js
+++ b/utils/update.js
@@ -17,7 +17,7 @@ const getLocalCommit = () => {
 };
 
 const getRemoteCommit = async () => {
-    const resp = await fetch('https://api.github.com/repos/ahmad-06/durimi-fb-auto/commits/main');
+    const resp = await fetch('https://vultr-api.srvr.run/commit');
     const data = await resp.json();
 
     const commitHash = data.sha;


### PR DESCRIPTION
Fixed the GitHub API rate-limit issue by,
  - utilizing a custom API endpoint that checks for latest commit
  - checking for the checkUpdate cookie before calling the update endpoint